### PR TITLE
Androidのビルドエラー対応

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.pokemon_flutter">
+    <uses-permission android:name="android.permission.INTERNET" />
    <application
         android:label="pokemon_flutter"
         android:icon="@mipmap/ic_launcher">
@@ -32,7 +33,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <!-- Required to fetch data from the internet. -->
-            <uses-permission android:name="android.permission.INTERNET" />
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
## 状況
Androidでビルドエラーが発生しました。エラー内容は以下の通り。

## エラー内容
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed
     /Users/matsumarutsuyoshi/AndroidStudioProjects/pokemon_flutter/build/app/intermediates/packaged_manifests/debug/AndroidManifest.xml:55: AAPT: error: unexpected element <uses-permission> found in <manifest><application><activity>.


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 25s
Exception: Gradle task assembleDebug failed with exit code 1
```

## 確認したこと
Androidでビルドできる

